### PR TITLE
Initialise when loading historic user records

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,10 +281,10 @@ Since the user in the example above won't be initialized, we have to do it manua
 
 ```php
 // Initialize if not initialized before.
-$user->config()->initialize();
+$user->settings()->initialize();
 
 // Forcefully initialize, even if already initialized.
-$user->config()->initialize(true);
+$user->settings()->initialize(true);
 ```
 
 #### Checking settings initialization
@@ -292,7 +292,7 @@ $user->config()->initialize(true);
 You can check if a user configuration has been initialized or not using `isInitialized()`.
 
 ```php
-if ($user->config()->isInitialized()) {
+if ($user->settings()->isInitialized()) {
     return 'You have a config!';
 }
 ```

--- a/src/HasConfig.php
+++ b/src/HasConfig.php
@@ -49,6 +49,21 @@ trait HasConfig
                 }
             }
         );
+        
+        static::retrieved(
+            static function (Model $model): void {
+                // Initialise when loading models created prior to implementing laraconfig
+                if (
+                    (!method_exists($model, 'shouldInitializeConfig') || $model->shouldInitializeConfig()) &&
+                    !$model->settings()->isInitialized()
+                ) {
+                    // Initialise the settings
+                    $model->settings()->initialize();
+                    // Unset loaded settings relationship to force Eloquent to refresh the bag
+                    unset($model->settings);
+                }
+            }
+        );
 
         static::deleting(
             static function (Model $model): void {


### PR DESCRIPTION
Corrected code sample in documentation.

Changed:

```
$user->config()->initialize();
```

to:

```
$user->settings()->initialize();
```