### PR TITLE
converting single slash to double slash before inserting className

### DIFF
--- a/src/Migrator/Pipes/CreateNewMetadata.php
+++ b/src/Migrator/Pipes/CreateNewMetadata.php
@@ -150,7 +150,7 @@ class CreateNewMetadata
                     ->select([
                     DB::raw("'{$metadata->getKey()}' as metadata_id"),
                     DB::raw("{$model->getKeyName()} as settable_id"),
-                    DB::raw("'{$model->getMorphClass()}' as settable_type"),
+                    DB::raw("'".addcslashes($model->getMorphClass(), '\\') ."' as settable_type"),
                     DB::raw("'{$metadata->getRawOriginal('default', 'NULL')}' as value"),
                     DB::raw("'{$this->now->toDateTimeString()}' as created_at"),
                     DB::raw("'{$this->now->toDateTimeString()}' as updated_at"),

--- a/src/Migrator/Pipes/CreateNewMetadata.php
+++ b/src/Migrator/Pipes/CreateNewMetadata.php
@@ -150,7 +150,7 @@ class CreateNewMetadata
                     ->select([
                     DB::raw("'{$metadata->getKey()}' as metadata_id"),
                     DB::raw("{$model->getKeyName()} as settable_id"),
-                    DB::raw("'".addcslashes($model->getMorphClass(), '\\') ."' as settable_type"),
+                    DB::raw("'". str_replace("\\\\", "\\", addcslashes($model->getMorphClass(), '\\'))."' as settable_type"),
                     DB::raw("'{$metadata->getRawOriginal('default', 'NULL')}' as value"),
                     DB::raw("'{$this->now->toDateTimeString()}' as created_at"),
                     DB::raw("'{$this->now->toDateTimeString()}' as updated_at"),


### PR DESCRIPTION
Issue:
#22 
converting single slash to double slash before inserting class name to table `user_settings` field `settable_type`