### PR TITLE
Remove backslash to \Models before add namespace that already has \ a…

### DIFF
--- a/src/Migrator/Pipes/FindModelsWithSettings.php
+++ b/src/Migrator/Pipes/FindModelsWithSettings.php
@@ -86,6 +86,7 @@ class FindModelsWithSettings
                 ->ltrim('app\\')
                 ->rtrim('.php')
                 ->replace(DIRECTORY_SEPARATOR, '\\')
+                ->ltrim('\\')
                 ->start('\\'.$namespace);
 
             try {


### PR DESCRIPTION
Remove backslash to \Models before add namespace that already has \ at the end.
Fix to #21

Es:
\App\\Models\MyModel  to  \App\Models\MyModel